### PR TITLE
Intermediate files now generated within $SAFELIGHT_DIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Compiled source #
 ###################
-safelightTmp/*
+bin/*
 *.o
 *.nexe
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Compiled source #
 ###################
+safelightTmp/*
 *.o
 *.nexe
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,7 @@ Navigate to http://[hostname]:6502 in your Chrome browser.
 ![safelight_start](images/readmeImages/safelight_start.png "safelight_start")  
 Enjoy using Safelight!
 ### Cleaning dependencies and executables:
-```shEnable Native Client under chrome://flags/#enable-nacl and restart Chrome.
-
+```sh
 $ ./safelight/clean.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ABOUT SAFELIGHT
 ================
 Safelight is a web application that aids in devoloping Halide programs.  
-It currently works for NaCl-enabled x86-64 Linux machines running the PNaCl
+It currently works for NaCl-enabled x86-64 Linux and Mac OS machines running the PNaCl
 binary distribution of Halide.  
 Current features include:
 
@@ -9,7 +9,7 @@ Current features include:
 - UI that displays a filter's Stmt, Assembly, and Stdout.
 - UI that displays input parameters and result outputs.
 - A display of a run's processing time.
-- Options for number of runtime threads.
+- Control over number of runtime threads.
 
 >This is not an official Google product.
 
@@ -17,7 +17,7 @@ Current features include:
 HOW TO SETUP SAFELIGHT
 =======================
 ### Requirements:
-- x86_64 Linux
+- x86_64 Linux or Mac
 - [Google Chrome](https://www.google.com/chrome/browser/)
 - [NaCl SDK](https://developer.chrome.com/native-client/sdk/download) (Pepper 42 or later)
 - [Go](https://golang.org/dl/)
@@ -27,7 +27,8 @@ HOW TO SETUP SAFELIGHT
 
             $ ./safelight/getPnaclHalide.sh
             $ source ~/.bashrc
-      -  `getPnaclHalide.sh` will download the correct Halide distribution, install it within your safelight directory, and export HALIDE_DIR to your *.bashrc*.  
+      -  If on Linux, `getPnaclHalide.sh` will download the correct Halide binary distribution, install it within your safelight directory, and export **HALIDE_DIR** to your *.bashrc*.
+      -  If on Mac, `getPnaclHalide.sh` will provide you the link to download the correct Halide binary distribution, but you must extract it and point **HALIDE_DIR** to it manually.
     - **Note: Using a non-PNaCl version of Halide (e.g. Trunk) will result in linker errors.**
 
 
@@ -35,11 +36,11 @@ HOW TO SETUP SAFELIGHT
 -  Ensure that all of the following environment variables are exported.  Paths must be absolute.
 	-  **SAFELIGHT_DIR**=*[path-to-Safelight]/safelight/*
 	-  **HALIDE_DIR**=*[path-to-Halide]/halide/*
-	    -  `getPnaclHalide.sh` automatically exports HALIDE_DIR to your *.bashrc*.
+	    -  If on Linux, `getPnaclHalide.sh` automatically exports HALIDE_DIR to your *.bashrc*.
 	-  **NACL_PEPPER_DIR**=*[path-to-NaCl]/nacl_sdk/pepper_[version-number]/*
 
 ### Enabling NaCl:
--   Enable Native Client under [chrome://flags/#enable-nacl](chrome://flags/#enable-nacl) and restart Chrome.
+-   Enable Native Client under chrome://flags/#enable-nacl and restart Chrome.
 
 ### Running the Server:
 ```sh
@@ -58,7 +59,8 @@ Navigate to http://[hostname]:6502 in your Chrome browser.
 ![safelight_start](images/readmeImages/safelight_start.png "safelight_start")  
 Enjoy using Safelight!
 ### Cleaning dependencies and executables:
-```sh
+```shEnable Native Client under chrome://flags/#enable-nacl and restart Chrome.
+
 $ ./safelight/clean.sh
 ```
 

--- a/exportEnv.sh
+++ b/exportEnv.sh
@@ -39,13 +39,13 @@ fi
 
 export NACL_TOOLCHAIN_BIN="${NACL_PEPPER_DIR}/toolchain/${os}_pnacl/bin/"
 export NACL_PEPPER_INCLUDE="${NACL_PEPPER_DIR}/include/"
-export SAFELIGHT_TMP="/tmp/safelightTmp"
+export SAFELIGHT_TMP="${SAFELIGHT_DIR}/safelightTmp/"
 export COMPILE_FLAGS="-Wall -Werror -Wno-unused-function -Wcast-qual -fno-rtti"
-export SAFELIGHT_PREBUILTDIR="/tmp/safelightPrebuiltNexeDir"
+export SAFELIGHT_PREBUILTDIR="${SAFELIGHT_TMP}/safelightPrebuiltNexeDir"
 export NEXE_RELEASE_DIR="${NACL_PEPPER_DIR}/lib/clang-newlib"
 export NEXE_LINKING_FLAGS="-Lhalide/bin -lppapi -lppapi_cpp"
-export SAFELIGHT_OUTPUT="$SAFELIGHT_TMP/output/"
-export GOPATH="$SAFELIGHT_DIR/server/"
+export SAFELIGHT_OUTPUT="${SAFELIGHT_TMP}/output/"
+export GOPATH="${SAFELIGHT_DIR}/server/"
 
 COPY_TYPES=(uint8 uint16 float32)
 INPUT_TYPES=(float32 float64 int8 int16 int32 uint8 uint16 uint32)

--- a/exportEnv.sh
+++ b/exportEnv.sh
@@ -39,7 +39,7 @@ fi
 
 export NACL_TOOLCHAIN_BIN="${NACL_PEPPER_DIR}/toolchain/${os}_pnacl/bin/"
 export NACL_PEPPER_INCLUDE="${NACL_PEPPER_DIR}/include/"
-export SAFELIGHT_TMP="${SAFELIGHT_DIR}/safelightTmp/"
+export SAFELIGHT_TMP="${SAFELIGHT_DIR}/bin/"
 export COMPILE_FLAGS="-Wall -Werror -Wno-unused-function -Wcast-qual -fno-rtti"
 export SAFELIGHT_PREBUILTDIR="${SAFELIGHT_TMP}/safelightPrebuiltNexeDir"
 export NEXE_RELEASE_DIR="${NACL_PEPPER_DIR}/lib/clang-newlib"

--- a/server/src/main/safelight_server.go
+++ b/server/src/main/safelight_server.go
@@ -33,12 +33,12 @@ import (
 
 // Flags
 var (
-	tempDir         = flag.String("tempDir", "/tmp/", "Directory for temporary .nexe")
-	htmlIndex       = flag.String("htmlIndex", "safelight/ui/index.html", "HTML Index file")
+	tempDir         = flag.String("tempDir", os.Getenv("SAFELIGHT_TMP"), "Directory for temporary .nexe")
+	htmlIndex       = flag.String("htmlIndex", os.Getenv("SAFELIGHT_DIR") + "/ui/index.html", "HTML Index file")
 	port            = flag.Int("port", 6502, "port for http")
 	cacheSize       = flag.Int("cacheSize", 32, "Size for LRU cache")
 	timeout         = flag.Duration("timeout", 5*60*time.Second, "timeout for building + running generator")
-	prebuiltNexeDir = flag.String("prebuiltNexeDir", "/tmp/safelightPrebuiltNexeDir", "prebuilt nexe dir")
+	prebuiltNexeDir = flag.String("prebuiltNexeDir", os.Getenv("SAFELIGHT_PREBUILTDIR"), "prebuilt nexe dir")
 )
 
 // Misc globals


### PR DESCRIPTION
-Instead of previously storing all intermediate files in /tmp, we now store them in $SAFELIGHT_DIR/safelightTmp.
-README.md is updated to reflect compatibility with Mac OS.
